### PR TITLE
sendSequenceCommand fix callback

### DIFF
--- a/alexa-remote.js
+++ b/alexa-remote.js
@@ -1382,13 +1382,13 @@ class AlexaRemote extends EventEmitter {
     }
 
     sendSequenceCommand(serialOrName, command, value, callback) {
-        let dev = this.find(serialOrName);
-        if (!dev) return callback && callback(new Error ('Unknown Device or Serial number', null));
-
         if (typeof value === 'function') {
             callback = value;
             value = null;
         }
+
+        let dev = this.find(serialOrName);
+        if (!dev) return callback && callback(new Error ('Unknown Device or Serial number', null));
 
         let seqCommandObj;
         if (typeof command === 'object') {


### PR DESCRIPTION
if callback is given as 3rd argument and no device is found then the callback is never called,
so reassign arguments first