### PR TITLE
changed require to requireUncached for alexa-cookie2

### DIFF
--- a/alexa-remote.js
+++ b/alexa-remote.js
@@ -13,6 +13,11 @@ const AlexaWsMqtt = require('./alexa-wsmqtt.js');
 
 const EventEmitter = require('events');
 
+function requireUncached(mod) {
+	delete require.cache[require.resolve(mod)];
+	return require(mod);
+}
+
 function _00(val) {
     let s = val.toString();
     while (s.length < 2) s = '0' + s;
@@ -603,12 +608,12 @@ class AlexaRemote extends EventEmitter {
     }
 
     generateCookie(email, password, callback) {
-        if (!this.alexaCookie) this.alexaCookie = require('alexa-cookie2');
+		if (!this.alexaCookie) this.alexaCookie = requireUncached('alexa-cookie2');
         this.alexaCookie.generateAlexaCookie(email, password, this._options, callback);
     }
 
     refreshCookie(callback) {
-        if (!this.alexaCookie) this.alexaCookie = require('alexa-cookie2');
+        if (!this.alexaCookie) this.alexaCookie = requireUncached('alexa-cookie2');
         this.alexaCookie.refreshAlexaCookie(this._options, callback);
     }
 


### PR DESCRIPTION
Currently all `alexa-remote` instances share one `alexa-cookie2` module object.
As a result when you **.init()** ialize a second `alexa-remote` instance it fails authentication even if you use exactly the same arguments. 
By using requireUncached each `alexa-remote` instance has its own `alexa-cookie2` module.

I noticed this issue for the case where email and password and no cookie is provided and with Proxy mode disabled.