### PR TITLE
fix pongTimeout clear

### DIFF
--- a/alexa-wsmqtt.js
+++ b/alexa-wsmqtt.js
@@ -94,7 +94,7 @@ class AlexaWsMqtt extends EventEmitter {
                 this.pingPongInterval = null;
             }
             if (this.pongTimeout) {
-                clearInterval(this.pongTimeout);
+                clearTimeout(this.pongTimeout);
                 this.pongTimeout = null;
             }
             if (code === 4001 && reason.startsWith('before - Could not find any')) { // code = 40001, reason = "before - Could not find any vali"


### PR DESCRIPTION
clearInterval does not clear timeouts in node v8 so it can crash with a "TypeError: Cannot read property 'close' of null" at alexa-wsmqtt.js:174:44