### PR TITLE
Emit cookie event

### DIFF
--- a/alexa-remote.js
+++ b/alexa-remote.js
@@ -65,6 +65,7 @@ class AlexaRemote extends EventEmitter {
         }
         this._options.csrf = this.csrf;
         this._options.cookie = this.cookie;
+        this.emit('cookie', this.cookie, this.csrf);
     }
 
     init(cookie, callback) {


### PR DESCRIPTION
Applications may want to store a new cookie, such they can supply it again in case of restarts.