### PR TITLE
Set missing Accept Header

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ Thank you for that work.
 
 ## Changelog:
 
+### 3.8.1 (2021-06-02)
+* (bbindreiter) Set missing Accept Header
+
 ### 3.8.0 (2021-05-11)
 * (Apollon77) Always recognize "alexa" as wakeword to handle commands via the apps correctly
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Thank you for that work.
 
 ## Changelog:
 
-### 3.8.1 (2021-06-02)
+### __WORK_IN PROGRESS__
 * (bbindreiter) Set missing Accept Header
 
 ### 3.8.0 (2021-05-11)

--- a/alexa-remote.js
+++ b/alexa-remote.js
@@ -794,6 +794,7 @@ class AlexaRemote extends EventEmitter {
             headers: {
                 'User-Agent' : this._options.userAgent,
                 'Content-Type': 'application/json; charset=UTF-8',
+                'Accept': 'application/json',
                 'Referer': `https://alexa.${this._options.amazonPage}/spa/index.html`,
                 'Origin': `https://alexa.${this._options.amazonPage}`,
                 //'Content-Type': 'application/json',
@@ -830,6 +831,7 @@ class AlexaRemote extends EventEmitter {
         delete logOptions.headers['Accept-Encoding'];
         delete logOptions.headers['User-Agent'];
         delete logOptions.headers['Content-Type'];
+	    delete logOptions.headers['Accept'];
         delete logOptions.headers.Referer;
         delete logOptions.headers.Origin;
         this._options.logger && this._options.logger('Alexa-Remote: Sending Request with ' + JSON.stringify(logOptions) + ((options.method === 'POST' || options.method === 'PUT' || options.method === 'DELETE') ? ' and data=' + flags.data : ''));

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "alexa-remote2",
-  "version": "3.8.0",
+  "version": "3.8.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "alexa-remote2",
-  "version": "3.8.1",
+  "version": "3.8.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alexa-remote2",
-  "version": "3.8.1",
+  "version": "3.8.0",
   "description": "Remote Control for amazon echo devices",
   "author": {
     "name": "Apollon77",
@@ -14,10 +14,6 @@
     {
       "name": "Apollon77",
       "email": "iobroker@fischer-ka.de"
-    },
-    {
-      "name": "bbindreiter",
-      "email": "bernd.bindreiter@gmail.com"
     }
   ],
   "homepage": "https://github.com/Apollon77/alexa-remote",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alexa-remote2",
-  "version": "3.8.0",
+  "version": "3.8.1",
   "description": "Remote Control for amazon echo devices",
   "author": {
     "name": "Apollon77",
@@ -14,6 +14,10 @@
     {
       "name": "Apollon77",
       "email": "iobroker@fischer-ka.de"
+    },
+    {
+      "name": "bbindreiter",
+      "email": "bernd.bindreiter@gmail.com"
     }
   ],
   "homepage": "https://github.com/Apollon77/alexa-remote",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,10 @@
     {
       "name": "Apollon77",
       "email": "iobroker@fischer-ka.de"
+    },
+    {
+      "name": "bbindreiter",
+      "email": "bernd.bindreiter@gmail.com"
     }
   ],
   "homepage": "https://github.com/Apollon77/alexa-remote",


### PR DESCRIPTION
Hi @Apollon77! One of the libraries using your fork `node-red-contrib-alexa-remote-cakebaked` stopped working. You can read about it here https://github.com/cakebake/node-red-contrib-alexa-remote-cakebaked/issues/22. Turned out it's because the http requests made to `/api/bootstrap?version=0` are now requiring the Accept Header to be set.

This PR also increases the version to 3.8.1. Your approval assumed, please release this version so all affected libs can updated their dependencies. 

Thank you very much!