### PR TITLE
Allow csrf to be updated on cookie refresh and add 401 error handling

### DIFF
--- a/alexa-remote.js
+++ b/alexa-remote.js
@@ -49,8 +49,7 @@ class AlexaRemote extends EventEmitter {
 
         if (!this.cookie || typeof this.cookie !== 'string') return;
         let ar = this.cookie.match(/csrf=([^;]+)/);
-        if (!ar || ar.length < 2) ar = this.cookie.match(/csrf=([^;]+)/);
-        if (!this.csrf && ar && ar.length >= 2) {
+        if (ar && ar.length >= 2) {
             this.csrf = ar[1];
         }
         if (!this.csrf) {
@@ -757,6 +756,11 @@ class AlexaRemote extends EventEmitter {
     httpsGetCall(path, callback, flags = {}) {
 
         const handleResponse = (err, res, body) => {
+            if (!err && typeof res.statusCode === 'number' && res.statusCode == 401) {
+                this._options.logger && this._options.logger('Alexa-Remote: Response: 401 Unauthorized');
+                return callback(new Error('401 Unauthorized'), null);
+            }
+
             if (err || !body) { // Method 'DELETE' may return HTTP STATUS 200 without body
                 this._options.logger && this._options.logger('Alexa-Remote: Response: No body');
                 return typeof res.statusCode === 'number' && res.statusCode >= 200 && res.statusCode < 300 ? callback(null, {'success': true}) : callback(new Error('no body'), null);


### PR DESCRIPTION
_if (!this.csrf && ar && ar.length >= 2) {_
prevents the csrf being updated after a re-init with former registration data has returned a new csrf, this will result in 401 errors on certain commands (such as speech) if the csrf is out of date.

Also this doesnt appear to do anything:
if (!ar || ar.length < 2) ar = this.cookie.match(/csrf=([^;]+)/);

Also added handling of 401 errors (otherwise the failure is silent)

Should fix:
#57
fixes bbindreiter/node-red-contrib-alexa-remote2-applestrudel#2
fixes cakebake/node-red-contrib-alexa-remote-cakebaked#31


