### PR TITLE
removing relationship query parameter

### DIFF
--- a/alexa-remote.js
+++ b/alexa-remote.js
@@ -2954,7 +2954,7 @@ class AlexaRemote extends EventEmitter {
     }
 
     getSmarthomeDevices(callback) {
-        this.httpsGet ('/api/phoenix?includeRelationships=true', function (err, res) {
+        this.httpsGet ('/api/phoenix', function (err, res) {
             if (err || !res || !res.networkDetail) return callback(err, res);
             try {
                 res = JSON.parse(res.networkDetail);


### PR DESCRIPTION
I'm not sure why but the `includeRelationships` parameter yields a 429 error despite the fact that the module isn't really flooding the api with requests. Hope this looks good.