### PR TITLE
Names is returning Serial and not string

### DIFF
--- a/alexa-remote.d.ts
+++ b/alexa-remote.d.ts
@@ -278,7 +278,7 @@ declare module "alexa-remote2" {
         cookieData?: string;
         baseUrl: string;
         friendlyNames: Record<string, string>;
-        names: Record<string, string>;
+        names: Record<string, Serial>;
         lastAuthCheck: number | null;
 
         setCookie(_cookie: string): void;


### PR DESCRIPTION
When using typescript definitions, apparently names returns Serial.
Currently, a cast needs to be done:
```typescript
const device: Serial = alexa.names["SomeDeviceName"] as unknown as Serial;
const serial = device.serialNumber;
alexa.sendSequenceCommand(serial, 'speak', data.text);
``` 